### PR TITLE
playground: Fixed bug that prevented playground from actually working

### DIFF
--- a/bin/run-playground
+++ b/bin/run-playground
@@ -2,7 +2,10 @@
 'use strict';
 
 const repl = require('repl');
+const { join } = require('path');
+const history = require('repl.history');
 const playground = require('../src/cli/playground');
 
-const ctx = repl.start().context;
-Object.assign(ctx, playground);
+const instance = repl.start();
+history(instance, join(process.env.HOME, '.node_repl_history'));
+Object.assign(instance.context, playground);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nconf": "^0.8.4",
     "neo4j-driver": "^1.1.0-M02",
     "ramda": "^0.24.1",
+    "repl.history": "^0.1.4",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/src/api/v1/effortTypes/effortTypesController.js
+++ b/src/api/v1/effortTypes/effortTypesController.js
@@ -43,7 +43,9 @@ function getEffortTypes () {
     MATCH (e:EffortType)-[:HAS_FIELD]->(:Field)
     RETURN e
     LIMIT 25
-    `
+    `,
+    {},
+    'e'
   );
 }
 

--- a/src/cli/playground/lib/index.js
+++ b/src/cli/playground/lib/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { inspect } = require('util');
+
 // Given a function `f` that may return a Promise or a value, `reify` returns
 // another function, such that upon being called, any Promise instance returned
 // by `f` will be resolved and printed to the console and undefined will be
@@ -8,7 +10,7 @@ function reify(f/*: (...args: Array<mixed>) => mixed*/)/*: mixed*/ {
   return function () {
     const ret = f.apply(this, arguments);
     if (ret instanceof Promise) {
-      ret.then(result => console.log(`[Fulfilled]\n`, result))
+      ret.then(result => console.log(`[Fulfilled]\n`, inspect(result, { depth: null })))
          .catch(err => console.error(err));
       return undefined;
     }
@@ -20,7 +22,7 @@ function methods(controller/*: Object*/, methods/*: Array<string>*/)/*: {[method
   const loaded = { };
   for (const method of methods) {
     if (controller && typeof controller[method] === 'function') {
-      loaded[method] = reify(loaded[method]);
+      loaded[method] = reify(controller[method]);
     }
   }
   return loaded;


### PR DESCRIPTION
- Added history to the playground repl
- Changed neo4jhelpers.query so that it accepts an optional key that allows you
to specify the return value key (e.g. 'e', 'n', etc) so only that result
is returned. This is useful for singleton queries so that
instead of receiving `{ 'e': NodeRecord(...) }`, you'll receive
`NodeRecord(...)`